### PR TITLE
02_query

### DIFF
--- a/01_intro/01_intro
+++ b/01_intro/01_intro
@@ -5,3 +5,41 @@ where start_station_name != end_station_name
 group by year, month
 order by year asc, month asc
 LIMIT 1000
+
+#combining two different datasets 
+
+WITH bicycle_rentals AS (
+  SELECT
+    COUNT(starttime) as num_trips,
+    EXTRACT(DATE from starttime) as trip_date
+  FROM `bigquery-public-data`.new_york_citibike.citibike_trips
+  GROUP BY trip_date
+),
+
+rainy_days AS
+(
+SELECT
+  date,
+  (MAX(prcp) > 5) AS rainy
+FROM (
+  SELECT
+    wx.date AS date,
+    IF (wx.element = 'PRCP', wx.value/10, NULL) AS prcp
+  FROM
+    `bigquery-public-data.ghcn_d.ghcnd_2016` AS wx
+  WHERE
+    wx.id = 'USW00094728'
+)
+GROUP BY
+  date
+)
+
+SELECT
+  ROUND(AVG(bk.num_trips)) AS num_trips,
+  wx.rainy
+FROM bicycle_rentals AS bk
+JOIN rainy_days AS wx
+ON wx.date = bk.trip_date
+GROUP BY wx.rainy
+
+Footer


### PR DESCRIPTION
#gender_and_tripduration 
SELECT  gender, tripduration 
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
LIMIT 5

#Aliasing column names with AS

SELECT  gender, tripduration AS rentalduration
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
LIMIT 5
#Running a Query without a column name

SELECT  gender, tripduration/60 
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
LIMIT 5

#Descriptive column names 

SELECT  gender, tripduration/60 as duration_minutes
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
LIMIT 5

#Filtering with where

SELECT  gender, tripduration
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
where tripduration < 600
LIMIT 5

#Filtering with boolean in the where clause 

SELECT  gender, tripduration
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
where tripduration >= 300 and  tripduration < 600 and gender = 'female'
LIMIT 5

#using parenthesis in the where clause 

SELECT  gender, tripduration
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
where (tripduration < 600 and gender = 'female') or gender = 'male'
LIMIT 5

#using select *

SELECT *
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
where start_station_name LIKE '%Riverside%'
LIMIT 5

#using except

SELECT * except(end_station_id, end_station_longitude)
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
where start_station_name LIKE '%Riverside%'
LIMIT 5

#using replace 
SELECT  * replace(num_bikes_available + 5 as num_bikes_available)
FROM `bigquery-public-data.new_york_citibike.citibike_stations` 
LIMIT 5

#subquery using WITH 

SELECT * FROM(
  SELECT GENDER, TRIPDURATION/60 as minutes 
  FROM `bigquery-public-data`.new_york_citibike.citibike_trips
)
where minutes < 10 
LIMIT 5

#subquery using WITH 
with all_trips as (

  SELECT GENDER, TRIPDURATION/60 as minutes 
  FROM `bigquery-public-data`.new_york_citibike.citibike_trips
)

select * from all_trips 
where minutes < 10 
LIMIT 5

#sorting with order by 
SELECT GENDER, TRIPDURATION/60 as minutes 
FROM `bigquery-public-data`.new_york_citibike.citibike_trips
order by minutes desc
LIMIT 5